### PR TITLE
adds plugin to allow absolute image sources in markdown/mdx

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,7 @@
 import { defineConfig } from 'astro/config';
 import process_anchors from "./src/plugins/process_anchors";
+import process_image_urls from './src/plugins/process_image_urls';
+
 
 import mdx from "@astrojs/mdx";
 
@@ -12,6 +14,7 @@ export default defineConfig({
   markdown: {
     rehypePlugins: [
       [process_anchors, {baseURL: process.env.BASEURL || '/'}],
+      [process_image_urls, {baseURL: process.env.BASEURL || '/'}]
     ]
   }
 });

--- a/src/plugins/process_image_urls.js
+++ b/src/plugins/process_image_urls.js
@@ -1,0 +1,50 @@
+/*
+ * The purpose of this is to process image in content sources to prevent
+ * local srcs (those starting with `/`) on cloud.gov pages feature branches from breaking.
+ * This should work for both markdown image like ![some text](somelink) as well as
+ * inline html image like <img src="somelink" alt="some text"/>
+ */
+
+
+import {visit} from 'unist-util-visit'
+
+import path from 'path'
+
+
+function process_mdx_image(node, baseURL) {
+    /**
+     * Process raw img tags in source content
+     * like <img src="/some_link" />
+     */
+
+    node.attributes.forEach(attr => {
+      if (attr.name === 'src' && attr.value.startsWith('/') && !attr.value.startsWith('//')) {
+        attr.value = path.join('/', baseURL, attr.value)
+      }
+    });
+  }
+
+  function process_markdown_image(node, baseURL) {
+     /**
+     * Process raw links in source content
+     * like ![some text](/some_link)
+     */
+
+    const properties = node.properties
+
+    if (properties.src.startsWith('/') && !properties.src.startsWith('//')) {
+      properties.src = path.join('/', baseURL, properties.src)
+    }
+  }
+  export default (options) => {
+    return tree => {
+      visit(tree,  [{"type": "element", "tagName": "img"}, {"type":'mdxJsxFlowElement', "name": "img"}], (node) => {
+        if (node.type === 'mdxJsxFlowElement') {
+            process_mdx_image(node, options.baseURL)
+        } else {
+            process_markdown_image(node, options.baseURL)
+        }
+      })
+    }
+  };
+


### PR DESCRIPTION
This adds a rehype plugin that adds the base_url to images so they don't break in markdown files. 