### PR TITLE
Add sitemap, which will be needed for search.gov.

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,14 +1,28 @@
+import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
+
 import { defineConfig } from 'astro/config';
 import process_anchors from "./src/plugins/process_anchors";
 import process_image_urls from './src/plugins/process_image_urls';
 import table_row_headers from './src/plugins/table_row_headers';
 
-import mdx from "@astrojs/mdx";
+const BASE_PATH = "/oasis-plus"
+
+function serialize(item) {
+  /* Rewrite urls for sitemap to put them under a subdirectory */
+  const url = new URL(item.url);
+  url.pathname = `${BASE_PATH}${url.pathname}`
+  item.url = url.toString();
+  return item;
+}
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [mdx()],
+  integrations: [mdx(), sitemap({
+    serialize
+})],
   outDir: '_site',
+  site: 'https://www.gsa.gov/',
   base: process.env.BASEURL,
   trailingSlash: 'always',
   markdown: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.5.5",
         "@astrojs/mdx": "^2.1.1",
+        "@astrojs/sitemap": "^3.1.1",
         "@uswds/uswds": "3.7.1",
         "astro": "^4.4.5",
         "typescript": "^5.3.3",
@@ -169,6 +170,15 @@
       },
       "engines": {
         "node": ">=18.14.1"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.1.1.tgz",
+      "integrity": "sha512-qPgdBIcDUaea98mTtLfi5z9oXZpzSjEn/kes70/Ex8FOZZ+DIHVKRYOLOtvy8p+FTXr/9oc7BjmIbTYmYLLJVg==",
+      "dependencies": {
+        "sitemap": "^7.1.1",
+        "zod": "^3.22.4"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1566,9 +1576,16 @@
       "version": "20.11.20",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
       "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
-      "devOptional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -2098,6 +2115,11 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -11362,6 +11384,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -11630,6 +11657,29 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "node_modules/sitemap": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
+      "integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=5.6.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -12466,8 +12516,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unherit": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@astrojs/check": "^0.5.5",
     "@astrojs/mdx": "^2.1.1",
+    "@astrojs/sitemap": "^3.1.1",
     "@uswds/uswds": "3.7.1",
     "astro": "^4.4.5",
     "typescript": "^5.3.3",


### PR DESCRIPTION
This includes a serializer to add oasis-plus/ to the path. It's not clear if this is needed yet and will depend on how GSA deals with sitemaps. Having it here now should make it quicker to modify as needed when the time comes. 