### PR TITLE
Update obtain-dpa.mdx

### DIFF
--- a/src/content/buyers-guide/obtain-dpa.mdx
+++ b/src/content/buyers-guide/obtain-dpa.mdx
@@ -71,7 +71,7 @@ To obtain an OASIS+ DPA, a warranted CO (appointed according to FAR 1.603) or an
 
         GSA will review your request, and you will receive a confirmation of the DPA via email within two business days. If you get a warrant after receiving training, you can request a DPA by emailing the respective program training at either [oasisplusDPA@gsa.gov](mailto:oasisplusDPA@gsa.gov) or [HCaTSTraining@gsa.gov](mailto:HCaTSTraining@gsa.gov).
 
-        Note: DPA requestors must provide a .gov or .mil email address. If you do not have a .gov or .mil work email address, please contact the OASIS+ Contracting Officer at [oasisplus@gsa.gov](mailto:oasisplus@gsa.gov) for assistance in requesting a DPA.
+        Note: DPA requestors must provide a .gov or .mil email address. If you do not have a .gov or .mil work email address, please contact the OASIS+ Contracting Officer at [oasisplusDPA@gsa.gov](mailto:oasisplusDPA@gsa.gov) for assistance in requesting a DPA.
 
     </ProcessListItem>
 </ProcessList>
@@ -79,7 +79,7 @@ To obtain an OASIS+ DPA, a warranted CO (appointed according to FAR 1.603) or an
 ## You have a DPA, now what?
 Once a CO receives a DPA, the individual is officially identified as an OCO. An OCO has the authority to award, administer, and modify task orders against the OASIS+ contracts. CO’s that do not have DPAs may not award task orders under OASIS+.
 
-DPAs are issued to individuals; not to agencies. DPAs may be revoked at the discretion of the OASIS+ Contracting Officer(s). There is no limit on DPA’s issued per agency, and individuals may repeat DPA training as often as they prefer. GSA cannot release the names of individuals with a DPA, even if requested by the agency; this information is Controlled Unclassified Information. 
+DPAs are issued to individuals; not to agencies. DPAs may be revoked at the discretion of the OASIS+ Contracting Officer(s). There is no limit on DPA’s issued per agency, and individuals may repeat DPA training as often as they prefer. 
 
 ### Support developing solicitations
 


### PR DESCRIPTION
Per Jon's comment, updated email address to oasisplusdpa@gsa.gov & removed the sentence "GSA cannot release the names of individuals with a DPA, even if requested by the agency; this information is Controlled Unclassified Information."