### PR TITLE
Fixed accessibility issue for title text too short 

### DIFF
--- a/src/content/contact/index.mdx
+++ b/src/content/contact/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Contact"
+title: "Contact OASIS+"
 description: "Get answers to your questions about OASIS+, Symphony, and more. Reach out to us via email or explore our other resources."
 order: 0
 slug: "index"

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,7 +8,7 @@ const entry = await getEntry('contact', 'index');
 const { Content} = await entry.render();
 
 ---
-<PageLayout title={`${entry.data.title} information`} description={entry.data.description}>
+<PageLayout title={entry.data.title} description={entry.data.description}>
     <PageContentLayoutWideScreen title={entry.data.title}>
         <div class="usa-prose">
             <Content />


### PR DESCRIPTION
- updated Contact page title and header to "Contact OASIS+"
- verified the AMP complaints went away. 