### PR TITLE
fix duplicate aria label

### DIFF
--- a/src/components/GSAHeader.astro
+++ b/src/components/GSAHeader.astro
@@ -85,7 +85,7 @@ show_site_link = show_site_link==='true';
     </nav>
     
     <!-- The pull-out drawer. Unlike traditional USWDS designs, this will always be visible -->
-    <nav aria-label="Primary navigation" class="oasis-nav-drawer usa-nav">
+    <nav aria-label="GSA navigation" class="oasis-nav-drawer usa-nav">
       <button type="button" class="usa-nav__close">
         <img src={ closeIcon.src } alt="Close" />
       </button>


### PR DESCRIPTION
This replaces the aria label of the side menu drawer to avoid having two "primary navigation" areas.