### PR TITLE
Mmeyer/last update

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { defineConfig } from 'astro/config';
 import process_anchors from "./src/plugins/process_anchors";
 import process_image_urls from './src/plugins/process_image_urls';
 import table_row_headers from './src/plugins/table_row_headers';
+import { remarkModifiedTime } from './src/plugins/remark-modified-time.mjs';
 
 const BASE_PATH = "/oasis-plus"
 
@@ -26,6 +27,7 @@ export default defineConfig({
   base: process.env.BASEURL,
   trailingSlash: 'always',
   markdown: {
+    remarkPlugins: [remarkModifiedTime],
     rehypePlugins: [
       [table_row_headers, {}],
       [process_anchors, {baseURL: process.env.BASEURL || '/'}],

--- a/federalist.json
+++ b/federalist.json
@@ -1,0 +1,3 @@
+{
+    "fullClone": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/sitemap": "^3.1.1",
         "@uswds/uswds": "3.7.1",
         "astro": "^4.4.11",
+        "dayjs": "^1.11.10",
         "typescript": "^5.3.3",
         "unist-util-visit": "^5.0.0"
       },
@@ -3905,6 +3906,11 @@
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "pa11y-ci:desktop": "pa11y-ci --config ./.pa11yci-desktop --sitemap http://localhost:4321/sitemap-0.xml  --sitemap-find \"^https://www.gsa.gov/oasis-plus/\" --sitemap-replace \"http://localhost:4321/\"",
     "pa11y-ci:mobile": "pa11y-ci --config ./.pa11yci-mobile --sitemap http://localhost:4321/sitemap-0.xml    --sitemap-find \"^https://www.gsa.gov/oasis-plus/\" --sitemap-replace \"http://localhost:4321/\"",
     "pa11y-ci:gh": "npx start-server-and-test serve http://localhost:4321 pa11y-ci"
-   
   },
   "dependencies": {
     "@astrojs/check": "^0.5.6",
@@ -24,6 +23,7 @@
     "@astrojs/sitemap": "^3.1.1",
     "@uswds/uswds": "3.7.1",
     "astro": "^4.4.11",
+    "dayjs": "^1.11.10",
     "typescript": "^5.3.3",
     "unist-util-visit": "^5.0.0"
   },

--- a/src/components/LastModified.astro
+++ b/src/components/LastModified.astro
@@ -1,11 +1,11 @@
 ---
-const {lastModified} = Astro.props;
+const {last_modified} = Astro.props;
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 
 dayjs.extend(utc);
 
-const updateDate = dayjs(lastModified)
+const updateDate = dayjs(last_modified)
   .utc()
   .format("MMMM DD, YYYY");
 ---

--- a/src/components/LastModified.astro
+++ b/src/components/LastModified.astro
@@ -1,0 +1,22 @@
+---
+const {lastModified} = Astro.props;
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+
+const updateDate = dayjs(lastModified)
+  .utc()
+  .format("MMMM DD, YYYY");
+---
+<div class="last-reviewed grid-container " id="page-last-reviewed">
+    Last updated: {updateDate}
+</div>
+
+<style>
+    .last-reviewed {
+        font-size: .75rem;
+        text-align: right;
+        margin-bottom: .5em;
+    }
+</style>

--- a/src/content/about/domains-labor-categories/naics-codes.mdx
+++ b/src/content/about/domains-labor-categories/naics-codes.mdx
@@ -3,6 +3,7 @@ title: NAICS codes by domain
 description: "Each OASIS+ domain contains multiple North American Industry Classification System (NAICS) codes. Learn which NAICs codes crosswalk to each domain."
 order: 3
 is_child: true
+last_modified: "February 27, 2024"
 ---
 
 import NAICSDomainTables from "@components/NAICSDomainTables.astro";

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,7 @@ import USAIdentifier from '@components/USAIdentifier.astro';
 import Banner from '@components/Banner.astro';
 import LastModified from "@components/LastModified.astro"
 
-const { title, description, show_site_link, lastModified=undefined} = Astro.props;
+const { title, description, show_site_link, lastModified} = Astro.props;
 ---
 <html lang="en">
   <head>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,7 @@ import USAIdentifier from '@components/USAIdentifier.astro';
 import Banner from '@components/Banner.astro';
 import LastModified from "@components/LastModified.astro"
 
-const { title, description, show_site_link, lastModified} = Astro.props;
+const { title, description, show_site_link, last_modified} = Astro.props;
 ---
 <html lang="en">
   <head>
@@ -37,7 +37,7 @@ const { title, description, show_site_link, lastModified} = Astro.props;
           <slot />
         </div>
       </div>
-      {lastModified && ( <LastModified lastModified={lastModified} /> )}
+      {last_modified && ( <LastModified last_modified={last_modified} /> )}
       <USAIdentifier />
     </div>
     <script is:inline src={`${import.meta.env.BASE_URL}js/uswds.min.js`}></script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,8 +2,9 @@
 import GSAHeader from '@components/GSAHeader.astro';
 import USAIdentifier from '@components/USAIdentifier.astro';
 import Banner from '@components/Banner.astro';
+import LastModified from "@components/LastModified.astro"
 
-const { title, description, show_site_link} = Astro.props;
+const { title, description, show_site_link, lastModified=undefined} = Astro.props;
 ---
 <html lang="en">
   <head>
@@ -36,6 +37,7 @@ const { title, description, show_site_link} = Astro.props;
           <slot />
         </div>
       </div>
+      {lastModified && ( <LastModified lastModified={lastModified} /> )}
       <USAIdentifier />
     </div>
     <script is:inline src={`${import.meta.env.BASE_URL}js/uswds.min.js`}></script>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,12 +1,16 @@
 ---
 import BaseLayout from "@layouts/BaseLayout.astro";
-const { title, description } = Astro.props;
+import LastModified from "@components/LastModified.astro"
+const { title, description, lastModified=undefined } = Astro.props;
+
 ---
 <BaseLayout title={title} description={description}>
-  
   <section class="grid-container usa-section">
     <div class="grid-row grid-gap">
       <slot />
     </div>
   </section>
+  {lastModified && (
+  <LastModified lastModified={lastModified} />
+  )}
 </BaseLayout>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,16 +1,12 @@
 ---
 import BaseLayout from "@layouts/BaseLayout.astro";
-import LastModified from "@components/LastModified.astro"
-const { title, description, lastModified=undefined } = Astro.props;
+const { title, description, lastModified } = Astro.props;
 
 ---
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} lastModified={lastModified}>
   <section class="grid-container usa-section">
     <div class="grid-row grid-gap">
       <slot />
     </div>
   </section>
-  {lastModified && (
-  <LastModified lastModified={lastModified} />
-  )}
 </BaseLayout>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,9 +1,9 @@
 ---
 import BaseLayout from "@layouts/BaseLayout.astro";
-const { title, description, lastModified } = Astro.props;
+const { title, description, last_modified } = Astro.props;
 
 ---
-<BaseLayout title={title} description={description} lastModified={lastModified}>
+<BaseLayout title={title} description={description} last_modified={last_modified}>
   <section class="grid-container usa-section">
     <div class="grid-row grid-gap">
       <slot />

--- a/src/pages/about/[...slug].astro
+++ b/src/pages/about/[...slug].astro
@@ -14,9 +14,10 @@ export async function getStaticPaths() {
 }
 
 const { entry, pages } = Astro.props;
-const { Content, headings } = await entry.render();
+const { Content, headings, remarkPluginFrontmatter:{lastModified} } = await entry.render();
+
 ---
-<PageLayout title={entry.data.title} description={entry.data.description}>
+<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
     <SideNav 
       title="About the GSA SmartPay Program"
       parent_path="about"

--- a/src/pages/about/[...slug].astro
+++ b/src/pages/about/[...slug].astro
@@ -14,10 +14,10 @@ export async function getStaticPaths() {
 }
 
 const { entry, pages } = Astro.props;
-const { Content, headings, remarkPluginFrontmatter:{lastModified} } = await entry.render();
+const { Content, headings, remarkPluginFrontmatter:{last_modified} } = await entry.render();
 
 ---
-<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
+<PageLayout title={entry.data.title} description={entry.data.description} last_modified={last_modified}>
     <SideNav 
       title="About the GSA SmartPay Program"
       parent_path="about"

--- a/src/pages/buyers-guide/[...slug].astro
+++ b/src/pages/buyers-guide/[...slug].astro
@@ -13,9 +13,9 @@ export async function getStaticPaths() {
   })
 }
 const { entry, pages } = Astro.props;
-const { Content, headings } = await entry.render();
+const { Content, headings, remarkPluginFrontmatter:{lastModified} } = await entry.render();
 ---
-<PageLayout title={entry.data.title} description={entry.data.description}>
+<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
   {entry.data.order == 0 ? 
     (
       <PageContentLayoutWideScreen title={entry.data.title}>

--- a/src/pages/buyers-guide/[...slug].astro
+++ b/src/pages/buyers-guide/[...slug].astro
@@ -13,9 +13,9 @@ export async function getStaticPaths() {
   })
 }
 const { entry, pages } = Astro.props;
-const { Content, headings, remarkPluginFrontmatter:{lastModified} } = await entry.render();
+const { Content, headings, remarkPluginFrontmatter:{last_modified} } = await entry.render();
 ---
-<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
+<PageLayout title={entry.data.title} description={entry.data.description} last_modified={last_modified}>
   {entry.data.order == 0 ? 
     (
       <PageContentLayoutWideScreen title={entry.data.title}>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -5,10 +5,10 @@ import PageLayout from '@layouts/PageLayout.astro'
 
 
 const entry = await getEntry('contact', 'index');
-const { Content} = await entry.render();
+const { Content, remarkPluginFrontmatter:{lastModified}} = await entry.render();
 
 ---
-<PageLayout title={entry.data.title} description={entry.data.description}>
+<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
     <PageContentLayoutWideScreen title={entry.data.title}>
         <div class="usa-prose">
             <Content />

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -5,10 +5,10 @@ import PageLayout from '@layouts/PageLayout.astro'
 
 
 const entry = await getEntry('contact', 'index');
-const { Content, remarkPluginFrontmatter:{lastModified}} = await entry.render();
+const { Content, remarkPluginFrontmatter:{last_modified}} = await entry.render();
 
 ---
-<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
+<PageLayout title={entry.data.title} description={entry.data.description} last_modified={last_modified}>
     <PageContentLayoutWideScreen title={entry.data.title}>
         <div class="usa-prose">
             <Content />

--- a/src/pages/events-training.astro
+++ b/src/pages/events-training.astro
@@ -5,10 +5,10 @@ import PageLayout from '@layouts/PageLayout.astro'
 
 
 const entry = await getEntry('events-training', 'index');
-const { Content, remarkPluginFrontmatter:{lastModified}} = await entry.render();
+const { Content, remarkPluginFrontmatter:{last_modified}} = await entry.render();
 
 ---
-<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
+<PageLayout title={entry.data.title} description={entry.data.description} last_modified={last_modified}>
     <PageContentLayoutWideScreen title={entry.data.title}>
         <div class="usa-prose">
             <Content />

--- a/src/pages/events-training.astro
+++ b/src/pages/events-training.astro
@@ -5,10 +5,10 @@ import PageLayout from '@layouts/PageLayout.astro'
 
 
 const entry = await getEntry('events-training', 'index');
-const { Content} = await entry.render();
+const { Content, remarkPluginFrontmatter:{lastModified}} = await entry.render();
 
 ---
-<PageLayout title={entry.data.title} description={entry.data.description}>
+<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
     <PageContentLayoutWideScreen title={entry.data.title}>
         <div class="usa-prose">
             <Content />

--- a/src/pages/resources/index.astro
+++ b/src/pages/resources/index.astro
@@ -5,10 +5,10 @@ import PageLayout from '@layouts/PageLayout.astro'
 
 
 const entry = await getEntry('resources', 'index');
-const { Content, remarkPluginFrontmatter:{lastModified} } = await entry.render();
+const { Content, remarkPluginFrontmatter:{last_modified} } = await entry.render();
 
 ---
-<PageLayout title={entry.data.title} description={entry.data.descriptio} lastModified={lastModified}>
+<PageLayout title={entry.data.title} description={entry.data.descriptio} last_modified={last_modified}>
     <PageContentLayoutWideScreen title={entry.data.title}>
         <div class="usa-prose oasis-resourcetable">
             <Content />

--- a/src/pages/resources/index.astro
+++ b/src/pages/resources/index.astro
@@ -8,7 +8,7 @@ const entry = await getEntry('resources', 'index');
 const { Content, remarkPluginFrontmatter:{last_modified} } = await entry.render();
 
 ---
-<PageLayout title={entry.data.title} description={entry.data.descriptio} last_modified={last_modified}>
+<PageLayout title={entry.data.title} description={entry.data.description} last_modified={last_modified}>
     <PageContentLayoutWideScreen title={entry.data.title}>
         <div class="usa-prose oasis-resourcetable">
             <Content />

--- a/src/pages/resources/index.astro
+++ b/src/pages/resources/index.astro
@@ -5,10 +5,10 @@ import PageLayout from '@layouts/PageLayout.astro'
 
 
 const entry = await getEntry('resources', 'index');
-const { Content} = await entry.render();
+const { Content, remarkPluginFrontmatter:{lastModified} } = await entry.render();
 
 ---
-<PageLayout title={entry.data.title} description={entry.data.description}>
+<PageLayout title={entry.data.title} description={entry.data.descriptio} lastModified={lastModified}>
     <PageContentLayoutWideScreen title={entry.data.title}>
         <div class="usa-prose oasis-resourcetable">
             <Content />

--- a/src/pages/sellers-guide/[...slug].astro
+++ b/src/pages/sellers-guide/[...slug].astro
@@ -13,9 +13,9 @@ export async function getStaticPaths() {
   })
 }
 const { entry, pages } = Astro.props;
-const { Content, headings } = await entry.render();
+const { Content, headings, remarkPluginFrontmatter:{lastModified} } = await entry.render();
 ---
-<PageLayout title={entry.data.title} description={entry.data.description}>
+<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
   {entry.data.order == 0 ? 
     (
       <PageContentLayoutWideScreen title={entry.data.title}>

--- a/src/pages/sellers-guide/[...slug].astro
+++ b/src/pages/sellers-guide/[...slug].astro
@@ -13,9 +13,9 @@ export async function getStaticPaths() {
   })
 }
 const { entry, pages } = Astro.props;
-const { Content, headings, remarkPluginFrontmatter:{lastModified} } = await entry.render();
+const { Content, headings, remarkPluginFrontmatter:{last_modified} } = await entry.render();
 ---
-<PageLayout title={entry.data.title} description={entry.data.description} lastModified={lastModified}>
+<PageLayout title={entry.data.title} description={entry.data.description} last_modified={last_modified}>
   {entry.data.order == 0 ? 
     (
       <PageContentLayoutWideScreen title={entry.data.title}>

--- a/src/plugins/remark-modified-time.mjs
+++ b/src/plugins/remark-modified-time.mjs
@@ -1,0 +1,9 @@
+import { execSync } from "child_process";
+
+export function remarkModifiedTime() {
+  return function (tree, file) {
+    const filepath = file.history[0];
+    const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
+    file.data.astro.frontmatter.lastModified = result.toString();
+  };
+}

--- a/src/plugins/remark-modified-time.mjs
+++ b/src/plugins/remark-modified-time.mjs
@@ -1,6 +1,9 @@
 /**
- * This looks at the last git commit of the markdown files to determin the
+ * This looks at the last git commit of the markdown files to determine the
  * modification date. 
+ * 
+ * Alternatively users may override this date by adding a last_modified key to front-matter
+ * with the date as a string.
  * 
  * When running on cloud.gov pages, it is important to tell cloud.gov to clone
  * the full repo — the default is a shallow clone. 
@@ -12,8 +15,15 @@ import { execSync } from "child_process";
 
 export function remarkModifiedTime() {
   return function (tree, file) {
-    const filepath = file.history[0];
-    const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
-    file.data.astro.frontmatter.lastModified = result.toString();
+    // allow content creators to override date in front-matter
+    const manual_last_modified_date = file.data.astro.frontmatter.last_modified
+    if (manual_last_modified_date) {
+      file.data.astro.frontmatter.lastModified = manual_last_modified_date
+    }
+    else {
+      const filepath = file.history[0];
+      const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
+      file.data.astro.frontmatter.lastModified = result.toString();
+    }
   };
 }

--- a/src/plugins/remark-modified-time.mjs
+++ b/src/plugins/remark-modified-time.mjs
@@ -1,3 +1,13 @@
+/**
+ * This looks at the last git commit of the markdown files to determin the
+ * modification date. 
+ * 
+ * When running on cloud.gov pages, it is important to tell cloud.gov to clone
+ * the full repo — the default is a shallow clone. 
+ * 
+ * This is specified in the root-level federalist.json file
+ * See: https://cloud.gov/pages/documentation/federalist-json/
+ */
 import { execSync } from "child_process";
 
 export function remarkModifiedTime() {
@@ -5,6 +15,5 @@ export function remarkModifiedTime() {
     const filepath = file.history[0];
     const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
     file.data.astro.frontmatter.lastModified = result.toString();
-    console.log("file:", filepath, "date:", result.toString())
   };
 }

--- a/src/plugins/remark-modified-time.mjs
+++ b/src/plugins/remark-modified-time.mjs
@@ -18,12 +18,12 @@ export function remarkModifiedTime() {
     // allow content creators to override date in front-matter
     const manual_last_modified_date = file.data.astro.frontmatter.last_modified
     if (manual_last_modified_date) {
-      file.data.astro.frontmatter.lastModified = manual_last_modified_date
+      file.data.astro.frontmatter.last_modified = manual_last_modified_date
     }
     else {
       const filepath = file.history[0];
       const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
-      file.data.astro.frontmatter.lastModified = result.toString();
+      file.data.astro.frontmatter.last_modified = result.toString();
     }
   };
 }

--- a/src/plugins/remark-modified-time.mjs
+++ b/src/plugins/remark-modified-time.mjs
@@ -5,5 +5,6 @@ export function remarkModifiedTime() {
     const filepath = file.history[0];
     const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
     file.data.astro.frontmatter.lastModified = result.toString();
+    console.log("file:", filepath, "date:", result.toString())
   };
 }


### PR DESCRIPTION
This adds last-updated dates to the front-matter of markdown/mdx files and places them at the bottom of the page.

The dates are derived from the last git commit. For this to work on Pages, we need to add a config to request that Pages perform a fullClone when building the site.

Authors can overwrite the date with a string literal in the front-matter `last_modified` key. This is helpful in cases like `/about/domains-labor-categories/naics-codes/` where the primary data is not in the markdown file, but in a separate yaml file making the last-updated date ambiguous. 