### PR TITLE
Normalize H1 Sizes

### DIFF
--- a/src/layouts/PageContentLayoutWideScreen.astro
+++ b/src/layouts/PageContentLayoutWideScreen.astro
@@ -3,8 +3,8 @@
 const { title } = Astro.props;
 ---
 <main id="main-content" class ="usa-layout-docs__main usa-prose usa-layout-docs">
+    <h1>{ title }</h1>
     <section class="wide-screen-content">
-        <h1>{ title }</h1>
         <slot />
     </section>
 </main>


### PR DESCRIPTION
This brings the  `<h1>` tags out of the section nesting so it picks up the css `usa-prose>h1` and matches size of other layouts.