### PR TITLE
Update research-contract-features.mdx

### DIFF
--- a/src/content/buyers-guide/research-contract-features.mdx
+++ b/src/content/buyers-guide/research-contract-features.mdx
@@ -18,8 +18,7 @@ As part of market research, you will need to determine which OASIS+ vehicle will
 
 The contract scope of OASIS+ is organized by domains, which are functional groupings of related services spanning multiple NAICS codes. Domains are designed to align order requirements to qualified industry partners. Each domain is limited to the NAICS codes and associated size standards specifically listed under that domain. 
 
-The OASIS+ contracts cover services that are: commercial and non-commercial; classified and unclassified; and Continental United States or CONUS and OCONUS or Outside the Continental United States. All OASIS+ task orders must be within scope of the respective OASIS+ IDIQ contract for which it is awarded, provided the Ordering Contracting Officer (OCO) determines the principal purpose NAICS code for the order to be one of the OASIS+ NAICS codes 
-[(see Appendix A)](#). If the OCO determines it is a NAICS code outside one of the OASIS+ NAICS codes, it is not within scope of OASIS+.
+The OASIS+ contracts cover services that are: commercial and non-commercial; classified and unclassified; and Continental United States or CONUS and OCONUS or Outside the Continental United States. All OASIS+ task orders must be within scope of the respective OASIS+ IDIQ contract for which it is awarded, provided the Ordering Contracting Officer (OCO) determines the principal purpose NAICS code for the order to be one of the OASIS+ NAICS codes. If the OCO determines it is a NAICS code outside one of the OASIS+ NAICS codes, it is not within scope of OASIS+.
 
 As you continue to review the factors that determine which OASIS+ contract to use, OCO's seeking further guidance are encouraged to submit a scope review.
 


### PR DESCRIPTION
Changed All OASIS+ task orders must be within scope of the respective OASIS+ IDIQ contract for which it is awarded, provided the Ordering Contracting Officer (OCO) determines the principal purpose NAICS code for the order to be one of the OASIS+ NAICS codes 
[(see Appendix A)](#). to 

All OASIS+ task orders must be within scope of the respective OASIS+ IDIQ contract for which it is awarded, provided the Ordering Contracting Officer (OCO) determines the principal purpose NAICS code for the order to be one of the OASIS+ NAICS codes. (removed link, ordering guide is no longer part of MVP)