### PR TITLE
Update index.mdx

### DIFF
--- a/src/content/sellers-guide/index.mdx
+++ b/src/content/sellers-guide/index.mdx
@@ -17,7 +17,7 @@ Below is a preview of the guide topics.
 
 
       Upcoming dates: 
-         - Awards issued: No later than [date].
+         - Awards issued: OASIS+ contracts are planned to be released on a rolling basis throughout Q3 and Q4 FY 2024. Until we award contracts, it is not possible to buy services.
          - Notice to proceed (ability to buy services): Estimated Q3 FY24.
          - Solicitations open for on-ramping: FY25. They will be continuously open from that point forward. 
 


### PR DESCRIPTION
 Awards issued: OASIS+ contracts are planned to be released on a rolling basis throughout Q3 and Q4 FY 2024. Until we award contracts, it is not possible to buy services. (was previously No later than [date].)
