### PR TITLE
Update research-contract-features.mdx

### DIFF
--- a/src/content/buyers-guide/research-contract-features.mdx
+++ b/src/content/buyers-guide/research-contract-features.mdx
@@ -45,15 +45,8 @@ If using a hybrid of contract types, please use separate Contract Line Item Numb
 
 ## Task order period of performances
 
-A task order must be solicited and awarded prior to the OASIS+ IDIQ ordering period end date. A task order period of performance (base period and all option periods) may extend up to five years after the OASIS+ IDIQ contract ordering period end date. Task order option periods may be exercised after the OASIS+ ordering period end date, provided that no task order option period of performance occurs beyond five years after the OASIS+ IDIQ ordering period end date. No task order performance can occur after the period of performance end date for the OASIS+ IDIQ.
-| OASIS+ contract end date  | Ordering period end date  | Period of performance  |
-| --------------------------| --------------------------| -----------------------|
-|OASIS+ UR IDIQ  | XX/XX/XXXX | XX/XX/XXXX|
-|OASIS+ SB IQIQ | XX/XX/XXXX | XX/XX/XXXX|
-|OASIS+ 8(a) IDIQ | XX/XX/XXXX | XX/XX/XXXX|
-|OASIS+ HUBZone IDIQ | XX/XX/XXXX | XX/XX/XXXX|
-|OASIS+ WOSB IDIQ| XX/XX/XXXX | XX/XX/XXXX|
-|OASIS+ SDVOSB IDIQ| XX/XX/XXXX | XX/XX/XXXX|
+A task order must be solicited and awarded prior to the OASIS+ IDIQ ordering period end date. A task order period of performance (base period and all option periods) may extend up to five years after the OASIS+ IDIQ contract ordering period end date. Task order option periods may be exercised after the OASIS+ ordering period end date, provided that no task order option period of performance occurs beyond five years after the OASIS+ IDIQ ordering period end date. No task order performance can occur after the period of performance end date for the OASIS+ IDIQ. The ordering period of performance for each contract will be finalized upon award and notice to proceed.
+
 
 The OASIS+ contracts will include the FAR 52.217-8, this clause does not flow down to task orders as it requires fill in information. The OASIS+ IDIQ’s performance must stop by the Period of Performance end date shown unless the OASIS+ IDIQ is extended by the GSA OASIS+ Contracting Officer. The (FAR 52.217-8) clause exercise is not guaranteed and is the sole decision of the GSA OASIS+ CO’s.
 


### PR DESCRIPTION
Table (first column: OASIS+ contract end date) removed, replaced with "The ordering period of performance for each contract will be finalized upon award and notice to proceed." 