### PR TITLE
Update index.mdx

### DIFF
--- a/src/content/events-training/index.mdx
+++ b/src/content/events-training/index.mdx
@@ -16,8 +16,7 @@ We host events and offer a variety of training to help you learn how to use our 
 ##  Upcoming events 
 - DPA training is scheduled to be released in May 2024. Links will be posted as registration becomes available. 
 
-[Visit the OASIS+ Interact Community for updates and announcements.] (https://buy.gsa.gov/interact/community/196/activity-feed)
-
+[Visit the OASIS+ Interact Community for updates and announcements.](https://buy.gsa.gov/interact/community/196/activity-feed)
 
 ## Training videos and courses
 - [PSHC Office Hours OASIS+ Overview](https://www.youtube.com/watch?v=1ft9kJBMK8A&list=PLvdwyPgXnxxVQag_kdAHeiKW1zQAs2wJQ&index=25&t=7s) - January 11, 2024

--- a/src/content/events-training/index.mdx
+++ b/src/content/events-training/index.mdx
@@ -14,22 +14,10 @@ export const components = {ul: IconList, li: ArrowListItem};
 We host events and offer a variety of training to help you learn how to use our contracts and buy professional services more efficiently and effectively. Training options include web-based, self-teaching tools, recorded webinars, podcasts, and on-site instructor-led.
 
 ##  Upcoming events 
-<CollectionList>
-    <CollectionListItem calendar_month="APR" calendar_day="4">
-    ### [HCaTS DPA Training](https://buy.gsa.gov/interact/community/17/activity-feed/post/9f5591b5-33ca-4700-ab70-d36c42668d8d/Mark_Your_Calendar_for_these_Valuable_April_2023_Webinars)
+- DPA training is scheduled to be released in May 2024. Links will be posted as registration becomes available. 
 
-    Join OASIS Program office for an overview and Delegation of Procurement Authority Training.
-    </CollectionListItem>
-</CollectionList>
-<CollectionList>
-    <CollectionListItem calendar_month="APR" calendar_day="13">
-    ### [Office Hours: Understanding Blanket Purchase Agreements (BPAs)](https://buy.gsa.gov/interact/community/17/activity-feed/post/9f5591b5-33ca-4700-ab70-d36c42668d8d/Mark_Your_Calendar_for_these_Valuable_April_2023_Webinars)
+[Visit the OASIS+ Interact Community for updates and announcements.] (https://buy.gsa.gov/interact/community/196/activity-feed)
 
-    Join us to learn more about the advantages of BPA's and earn one CLP.
-    </CollectionListItem>
-</CollectionList>
-## Past Events
-- [OASIS+ Office Hours Webinar - September 8, 2023](#)
 
 ## Training videos and courses
 - [PSHC Office Hours OASIS+ Overview](https://www.youtube.com/watch?v=1ft9kJBMK8A&list=PLvdwyPgXnxxVQag_kdAHeiKW1zQAs2wJQ&index=25&t=7s) - January 11, 2024


### PR DESCRIPTION
Past Events removed. Upcoming Events removed, replaced with text:
DPA training is scheduled to be released in May 2024. Links will be posted as registration becomes available.

Visit the OASIS+ Interact Community for updates and announcements. [links to https://buy.gsa.gov/interact/community/196/activity-feed]