### PR TITLE
Update index.astro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,7 +64,7 @@ const base_url = import.meta.env.BASE_URL;
       <p>Initial proposal submissions: Closed on October 20, 2023.</p>
         <p>Upcoming dates:</p>
         <ul>
-          <li>Awards issued: OASIS+ contracts are planned to be released on a rolling basis throughout Q3 and Q4 FY 2024. Until we award contracts, it is not possible to buy services. (was previously No later than [date].)
+          <li>Awards issued: OASIS+ contracts are planned to be released on a rolling basis throughout Q3 and Q4 FY 2024. Until we award contracts, it is not possible to buy services.
 </li>
           <li>Notice to proceed (ability to buy services): Estimated Q3 FY24.</li>
           <li>Solicitations open for on-ramping: FY25. They will be continuously open from that point forward.</li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,10 +61,11 @@ const base_url = import.meta.env.BASE_URL;
 
     <div class="grid-container">
       <USWSDAlert heading="Announcements and upcoming dates">
-      <p>Initial proposal submissions: Closed on October 23, 2023.</p>
+      <p>Initial proposal submissions: Closed on October 20, 2023.</p>
         <p>Upcoming dates:</p>
         <ul>
-          <li>Awards issued: No later than [date].</li>
+          <li>Awards issued: OASIS+ contracts are planned to be released on a rolling basis throughout Q3 and Q4 FY 2024. Until we award contracts, it is not possible to buy services. (was previously No later than [date].)
+</li>
           <li>Notice to proceed (ability to buy services): Estimated Q3 FY24.</li>
           <li>Solicitations open for on-ramping: FY25. They will be continuously open from that point forward.</li>
         </ul>


### PR DESCRIPTION
Awards issued: OASIS+ contracts are planned to be released on a rolling basis throughout Q3 and Q4 FY 2024. Until we award contracts, it is not possible to buy services. (was previously No later than [date].)
 Initial proposal submissions: Closed on October 20, 2023. (was previously: Closed on October 23, 2023.)