### PR TITLE
Update register-in-symphony.mdx

### DIFF
--- a/src/content/sellers-guide/register-in-symphony.mdx
+++ b/src/content/sellers-guide/register-in-symphony.mdx
@@ -13,7 +13,7 @@ export const components = {ul: IconList, li: ArrowListItem, table: TableBorderle
 import SummaryBox from "@components/SummaryBox.astro"
 
 
-The OASIS+ Program will use the [Symphony procurement suite tool](#), also referred to as the OASIS+ Submission Portal (OSP), for proposal submission, evaluations, and task order management. We have provided recorded training to walk you through system registration, proposal submission, and task order management.
+The OASIS+ Program will use the [Symphony procurement suite tool](#), also referred to as the OASIS+ Submission Portal (OSP), for proposal submission, evaluations, and task order management. We have provided recorded trainings to walk you through system registration, proposal submission, and task order management.
 
 All sellers who are interested in submitting proposals to the OASIS+ suite of contracts must register in Symphony. In order to register your business in Symphony you will need your company SAM or System for Award Management and Unique Entity ID or UEI.
 
@@ -26,7 +26,7 @@ All sellers who are interested in submitting proposals to the OASIS+ suite of co
 | Resource | Description |
 | --------------------------| --------------------------|
 |[Symphony Task Order System Reference Guide for Industry [PDF - 230 KB]](https://www.gsa.gov/system/files/OASIS_Symphony_Quick_Reference_for_Industry_-_April_2023%20%283%29.pdf) | Highlights resources and links to help navigate the tool. | 
-|[Symphony - The Task Order Tool That Works For You](https://youtu.be/cQ4zVfA8MAY) | Video tutorial that shows how customers (Ordering Contracting Officers (OCOs)) and industry partners how to receive, review, post, respond to and track RFIs and RFPs to fulfill requirements. | 
+|[Symphony - The Task Order Tool That Works For You](https://youtu.be/cQ4zVfA8MAY) | Video tutorial that shows how customers (Ordering Contracting Officers (OCOs)) and industry partners receive, review, post, respond to and track RFIs and RFPs to fulfill requirements. | 
 |[Getting started -  Frequently Asked Questions](https://gettingstarted.apexlogic.com/support/home) | Frequently asked questions about Symphony. | 
 |[Industry Support](https://industrysupport.apexlogic.com/support/solutions/35000143140)| Provides detailed support and instructions for tasks specific to sellers and industry users. |
 |[Symphony Contract Holder Quick Guide [PDF - 614 KB]](https://www.gsa.gov/system/files/OASIS_Contract_Holder_Quick_Guide_v2.pdf)|Provides instructions for key tasks within Symphony. |


### PR DESCRIPTION
Pluralized trainings in "We have provided recorded training".

Removed extra "how to" Video tutorial that shows how customers (Ordering Contracting Officers (OCOs)) and industry partners how to receive, review, post, respond to and track RFIs and RFPs to fulfill requirements. Consistent change with Buyers' guide language as well.