### PR TITLE
Fixing broken links

### DIFF
--- a/src/content/buyers-guide/index.mdx
+++ b/src/content/buyers-guide/index.mdx
@@ -54,7 +54,7 @@ OASIS+ is ready to meet your agency’s complex, integrated multiple service req
 
     </ContentListItem>
     <ContentListItem header="Prepare to develop your solicitation" img_src="images/buyers/prepare-solicitation-image.svg" img_alt="Person surrounded by text bubbles.">
-        ### [Obtain a Delegation of Procurement Authority](/buyers-guide/get-dpa/)
+        ### [Obtain a Delegation of Procurement Authority](/buyers-guide/obtain-dpa/)
 
         In order to solicit and place task orders under OASIS+, the Ordering Contracting Officer (OCO) must obtain a Delegation of Procurement Authority (DPA).
  

--- a/src/content/events-training/index.mdx
+++ b/src/content/events-training/index.mdx
@@ -24,7 +24,6 @@ We host events and offer a variety of training to help you learn how to use our 
 - [CSAW Learning Series](https://www.youtube.com/playlist?list=PLvdwyPgXnxxVslDBK5HYeekr4FY_nr-Pn)
 - [PSHC Industry Partner Briefing Recordings](https://www.youtube.com/playlist?list=PLvdwyPgXnxxUIh1e3H272MogI3HrLGzK9)
 - [PSHC Supplier Success Series](https://www.youtube.com/playlist?list=PLvdwyPgXnxxVVhrv4zziLpGgkngkZT1Pm)
-- [OASIS+ Delegation of Procurement Authority (DPA) Training](buyers-guide/obtain-dpa/)
 - [Online Defense Acquisition University or DAU training class](https://www.dau.edu/courses/wsc-005) 
 
 <SummaryBox header="Need to request a training?">

--- a/src/content/resources/index.mdx
+++ b/src/content/resources/index.mdx
@@ -46,4 +46,4 @@ We have resources to help you navigate the OASIS+ contract; as part of this, we 
 
 ## Trainings
 
-We offer a variety of on-demand and live trainings. [View all trainings](/events-training/).
+We offer a variety of on-demand and live trainings. [View all trainings](/events-training/)


### PR DESCRIPTION
Buyers guide landing page 
* Obtain a DPA - link is 404 - fixed 

Resources 
* View all trainings` link is 404- fixed


Events and training 
* OASIS+ Delegation of Procurement Authority Training link is 404 - removed (DPA training is not available yet)