### PR TITLE
Add an external link icon to the Interact Button on the home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -188,7 +188,7 @@ const base_url = import.meta.env.BASE_URL;
           Get the latest news and updates from the OASIS+ Interact community.
         </h3>
         <p>
-          <a href="https://buy.gsa.gov/interact/community/196/activity-feed" class="usa-button usa-button--outline">
+          <a href="https://buy.gsa.gov/interact/community/196/activity-feed" class="usa-button usa-button--outline usa-link--external text-no-wrap">
             Explore OASIS+ Interact Community
           </a>
         </p>


### PR DESCRIPTION
Adds an external link icon to the Interact Button on the home page and adjusts style to prevent the icon from wrapping.