### PR TITLE
Sellers guide and homepage alerts

### DIFF
--- a/src/content/sellers-guide/index.mdx
+++ b/src/content/sellers-guide/index.mdx
@@ -17,10 +17,9 @@ Below is a preview of the guide topics.
 
 
       Upcoming dates: 
-         - Awards issued: OASIS+ contracts are planned to be released on a rolling basis throughout Q3 and Q4 FY 2024. Until we award contracts, it is not       
-           possible to buy services.
-         - Notice to proceed (ability to buy services): Estimated Q3 FY24.
-         - Solicitations open for on-ramping: FY25. They will be continuously open from that point forward. 
+         - Estimated awards: Throughout Q3 and Q4 FY 2024       
+         - Notice to Proceed (ability to buy services): Estimated Q3 and Q4 FY 2024
+         - Solicitations re-open for on-ramping: FY 2025
 
    [Visit the OASIS+ Interact Community for additional updates and announcements.](https://buy.gsa.gov/interact/community/196/activity-feed) 
       

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,9 +64,9 @@ const base_url = import.meta.env.BASE_URL;
       <p>Initial proposal submissions: Closed on October 20, 2023.</p>
         <p>Upcoming dates:</p>
         <ul>
-          <li>Awards issued: OASIS+ contracts are planned to be released on a rolling basis throughout Q3 and Q4 FY 2024. Until we award contracts, it is not possible to buy services.</li>
-          <li>Notice to proceed (ability to buy services): Estimated Q3 FY24.</li>
-          <li>Solicitations open for on-ramping: FY25. They will be continuously open from that point forward.</li>
+          <li>Estimated awards: Throughout Q3 and Q4 FY 2024</li>
+          <li>Notice to Proceed (ability to buy services): Estimated Q3 and Q4 FY 2024</li>
+          <li>Solicitations re-open for on-ramping: FY 2025</li>
         </ul>
         <p>
           <a class="usa-link usa-link--external" href="https://buy.gsa.gov/interact/community/196/activity-feed">Visit the OASIS+ Interact Community for additional updates and announcements.</a>


### PR DESCRIPTION
Updated alerts copy on Sellers Guide and Homepage to:

Estimated awards: Throughout Q3 and Q4 FY 2024

Notice to Proceed (ability to buy services): Estimated Q3 and Q4 FY 2024

Solicitations re-open for on-ramping: FY 2025

