### PR TITLE
Ignore DAP iframes

### DIFF
--- a/.pa11yci-desktop
+++ b/.pa11yci-desktop
@@ -3,6 +3,7 @@
     "concurrency": 1,
     "standard": "WCAG2AA",
     "timeout": 10000,
+    "hideElements": "iframe",
     "chromeLaunchConfig": {
         "args": ["--no-sandbox"]
     }

--- a/.pa11yci-mobile
+++ b/.pa11yci-mobile
@@ -3,6 +3,7 @@
     "concurrency": 1,
     "standard": "WCAG2AA",
     "timeout": 10000,
+    "hideElements": "iframe",
     "chromeLaunchConfig": {
         "args": ["--no-sandbox"]
     },


### PR DESCRIPTION
The DAP snippet is inserting an `iframe` into the DOM, causing random failing pa11y tests. This workaround instructs pa11y to ignore `iframe` elements.