### PR TITLE
Fix link checker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,6 @@ jobs:
   broken_links:
     runs-on: ubuntu-latest
     needs: setup
-    if: false
     steps:
       - name: Checkout code from ${{ github.repository }}
         uses: actions/checkout@v3


### PR DESCRIPTION
Re-enabling the broken link checker for now. So far it hasn't failed, but it's still an optional check and is not mandatory for merging.