### PR TITLE
Fix extra <ul> bug found in site scan

### DIFF
--- a/src/components/SideNav.astro
+++ b/src/components/SideNav.astro
@@ -1,6 +1,4 @@
 ---
-import { any } from "astro/zod";
-
 /*
 Used for side navigation for OASIS+
 Headings default to null for pages without in page nav.

--- a/src/components/SideNav.astro
+++ b/src/components/SideNav.astro
@@ -1,4 +1,6 @@
 ---
+import { any } from "astro/zod";
+
 /*
 Used for side navigation for OASIS+
 Headings default to null for pages without in page nav.
@@ -39,7 +41,7 @@ pages.sort((a, b) => parseInt(a.data.order) - parseInt(b.data.order))
            ) 
           }
           <!--Sub menus for long page that needs in page navigation to H2 -->
-          {page.data.in_page_nav &&
+          {page.data.in_page_nav && headings.some(h => h.depth ==2) &&
             <ul class="usa-sidenav__sublist usa-sidenav__sublist_header">
               {id === page.id && headings
                 .filter(h => h.depth == 2)

--- a/src/content/buyers-guide/research-contract-features.mdx
+++ b/src/content/buyers-guide/research-contract-features.mdx
@@ -2,7 +2,6 @@
 title: "Research the OASIS+ contract features"
 description: "Understanding the OASIS+ contract features is required by the FAR and necessary for completing your contract file. Learn about the contract scope and more."
 order: 1
-in_page_nav: true
 ---
 
 import TableBorderless from "@components/TableBorderless.astro"


### PR DESCRIPTION
- Turns off `in_page` nav for `research-contract-features.mdx`
-  Adds check for… h2s before making ul element for child items in side nav to prevent empty elements