### PR TITLE
Rosamund reporting sellersguide - typo and updates

### DIFF
--- a/src/content/sellers-guide/index.mdx
+++ b/src/content/sellers-guide/index.mdx
@@ -27,21 +27,21 @@ Below is a preview of the guide topics.
 
 <ContentList>
     <ContentListItem 
-        header="I have an OASIS+ contract (content coming soon)" 
+        header="I have an OASIS+ contract" 
         img_src="images/sellers/have-a-contract-image.svg"
         img_alt="Person standing amidst a series of charts and graphs."    
     >
         ### [Confirm you’re registered in Symphony](/sellers-guide/register-in-symphony/)  
         Authorized employees must register in Symphony to manage task orders and complete administrative duties; check out the registration instructions to help you through the process.
 
-        ### Compete for and manage task orders in Symphony
+        ### [Compete for and manage task orders in Symphony](/sellers-guide/compete-for-task-orders)
         View and respond to solicitations/RFIs/RFPs, submit Q&A and proposals, manage task orders, and complete required reporting.
 
-        ### Administer your master contract and task orders  
-        - Learn how to submit requests for contract modifications, including novations
-        - Learn how to ensure your contract is in compliance
-        - Manage task order business administrative submissions 
-        - Complete required financial and other reporting through Sales Reporting Portal (SRP)
+        ### [Administer your master contract and task orders](/sellers-guide/make-changes-contract) 
+        View and respond to solicitations/RFIs/RFPs, submit Q&A and proposals, and manage task orders.
+
+        ### [Report sales in the FAS Sales Reporting Portal (SRP)](/sellers-guide/reporting) 
+        Review reporting requirements and discover how to use the SRP.
 
     </ContentListItem>
     <ContentListItem 

--- a/src/content/sellers-guide/reporting.mdx
+++ b/src/content/sellers-guide/reporting.mdx
@@ -5,7 +5,7 @@ order: 4
 ---
 import SummaryBox from "@components/SummaryBox.astro"
 
-The OASIS+ contract requires vendors to properly report sales in the FAS [Sales Reporting Portal (SRP)](https://srp.fas.gsa.gov/). SRP is the system used by FAS for Multiple Award Schedule (MAS) sales reporting, and echos the functionality vendors may be used to from other contracts in the Contract Payment and Reporting Module (CPRM) of ASSIST. Vendors must use SRP to:
+The OASIS+ contract requires vendors to properly report sales in the FAS [Sales Reporting Portal (SRP)](https://srp.fas.gsa.gov/). SRP is the system used by FAS for Multiple Award Schedule (MAS) sales reporting, and echoes the functionality vendors may be used to from other contracts in the Contract Payment and Reporting Module (CPRM) of ASSIST. Vendors must use SRP to:
 
 - Report new task orders awarded against their contract within 30 days after award.
 - Report invoices for each task order monthly, reporting “zero sales” if no invoices were issued.


### PR DESCRIPTION
Reporting:

SRP is the system used by FAS for Multiple Award Schedule (MAS) sales reporting, and echos the functionality /// changed echos to echoes

Sellers' guide:

- Remove "content coming soon" from I have an OASIS+ contract (content coming soon)

- link Compete for and manage task orders in Symphony to sellers-guide/compete-for-task-orders

- link Administer your master contract and task orders to sellers-guide/make-changes-contract , update description to read: View and respond to solicitations/RFIs/RFPs, submit Q&A and proposals, and manage task orders.

- Add Reporting section to card (after Administer your master contract and task orders)
 -- Title: Report sales in the FAS Sales Reporting Portal (SRP) (link to sellers-guide/reporting]
  -- Description: Review reporting requirements and discover how to use the SRP.

