### PR TITLE
fix link 404 error 

### DIFF
--- a/src/content/buyers-guide/index.mdx
+++ b/src/content/buyers-guide/index.mdx
@@ -54,7 +54,7 @@ This Buyers’ Guide explains how the OASIS+ contracts can be used to satisfy a 
 
         In order to solicit and place task orders under OASIS+, the OCO must obtain a Delegation of Procurement Authority (DPA).
 
-        ### [Learn how to use Symphony](resources/#proposal-submission-and-task-management)
+        ### [Learn how to use Symphony](/resources/#proposal-submission-and-task-management)
 
         Check out our Symphony resources; learn how to build submit proposals, manage task orders, and complete other tasks related to the buying process.
 

--- a/src/content/buyers-guide/index.mdx
+++ b/src/content/buyers-guide/index.mdx
@@ -56,7 +56,7 @@ This Buyers’ Guide explains how the OASIS+ contracts can be used to satisfy a 
 
         ### [Learn how to use Symphony](/resources/#proposal-submission-and-task-management)
 
-        Check out our Symphony resources; learn how to build submit proposals, manage task orders, and complete other tasks related to the buying process.
+        Check out our Symphony resources; learn how to build, submit proposals, manage task orders, and complete other tasks related to the buying process.
 
     </ContentListItem>
     <ContentListItem header="Develop the solicitation and award the task order" img_src="images/buyers/develop-solicitation-image.svg" img_alt="Person working on a laptop while drawing on a tablet.">


### PR DESCRIPTION
- fixed 404 error on link to "Learn how to use Symphony" on buyer's guide page