### PR TITLE
fix typo in dpa form and remove extra line-return in yaml doc

### DIFF
--- a/src/components/DPAForm.astro
+++ b/src/components/DPAForm.astro
@@ -410,7 +410,7 @@
             <input
                 class="usa-input"
                 data-error-id="dpa_other_method_missing_message"
-                data-error-msg="This field is required; please enter a training method/"
+                data-error-msg="This field is required; please enter a training method"
                 id="oasis-Other"
                 maxlength="255"
                 name="category[oasisplus][Othertrainingmethod]"

--- a/src/content/data/naics_codes_by_domain.yaml
+++ b/src/content/data/naics_codes_by_domain.yaml
@@ -616,7 +616,6 @@
   icon: images/domain-icons/logistics.svg
   clinKey: "XX = UR, SB, 8A, VO, WO, HZ"
   scopeAreas:
-  
     - Analysis & recommendation of support equipment
     - Cold chain medical supply services
     - Deployment logistics


### PR DESCRIPTION
Removes extra line in YAML file and fixes typo in validation message on DPA form.