### PR TITLE
remove broken regex from name fields - uswds says we should not valid…

### DIFF
--- a/src/components/DPAForm.astro
+++ b/src/components/DPAForm.astro
@@ -47,7 +47,6 @@
                 id="First_Name"
                 maxlength="100"
                 name="First_Name"
-                pattern="^(?! )[a-zA-Z\-. ]+$"
                 required="true"
                 type="text"
             />
@@ -64,7 +63,6 @@
                 id="Last_Name"
                 maxlength="100"
                 name="Last_Name"
-                pattern="^(?! )[a-zA-Z\-. ]+$"
                 required="true"
                 type="text"
             />
@@ -323,7 +321,7 @@
                 id="zip"
                 maxlength="10"
                 name="zip"
-                pattern="^[\\d]{5}((-|\+)[\\d]{4})?$"
+                pattern="^[\\d]{5}((-|\\+)[\\d]{4})?$"
                 required="true"
                 type="text"
             />


### PR DESCRIPTION
- Remove broken regex from name fields - uswds says we should not validate names (and this regex fails for common names). 
- Fix regex for zip — we need to escape backslashes in astro templates.