### PR TITLE
Mmeyer pa11y captcha fix

### DIFF
--- a/.pa11yci-desktop
+++ b/.pa11yci-desktop
@@ -3,7 +3,7 @@
     "concurrency": 1,
     "standard": "WCAG2AA",
     "timeout": 10000,
-    "hideElements": "iframe",
+    "hideElements": "iframe, .g-recaptcha-response",
     "chromeLaunchConfig": {
         "args": ["--no-sandbox"]
     }

--- a/.pa11yci-mobile
+++ b/.pa11yci-mobile
@@ -3,7 +3,7 @@
     "concurrency": 1,
     "standard": "WCAG2AA",
     "timeout": 10000,
-    "hideElements": "iframe",
+    "hideElements": "iframe, .g-recaptcha-response",
     "chromeLaunchConfig": {
         "args": ["--no-sandbox"]
     },

--- a/public/js/dpa-form.js
+++ b/public/js/dpa-form.js
@@ -9,15 +9,6 @@ document.addEventListener('DOMContentLoaded', function() {
       }).then(function(token) {
         if (token.length > 0) {
           document.getElementById('g-token').value = token;
-
-          // prevent a11y from complaining about the hidden textarea
-          // that google palces on the page
-          var textarea = document.getElementsByName("g-recaptcha-response")[0];
-          if (textarea) {
-            textarea.setAttribute("aria-hidden", "true");
-            textarea.setAttribute("aria-label", "unused");
-            textarea.setAttribute("aria-readonly", "true");
-          }
         }
       });
     });

--- a/src/components/DPAForm.astro
+++ b/src/components/DPAForm.astro
@@ -5,13 +5,6 @@
 <script is:inline type="text/javascript">
     var recaptcha_site_key = "6Ld9SegUAAAAAB-cac89z4iV1EzhN5va_TykKhAg";
 </script>
-<script
-    is:inline
-    type="text/javascript"
-    src="https://www.gstatic.com/recaptcha/releases/8k85QBI-qzxmenDv318AZH30/recaptcha__en.js"
-    crossorigin="anonymous"
-    integrity="sha384-YaLdSXMqm9CEKTpOkSnpu5vAhzVfmtaskI7GboiAj0dVtvfpzmGU1XBINZ7hs6ET"
-></script>
 
 <p class="margin-top-4">
     <strong>All fields are required.</strong>


### PR DESCRIPTION
- Add captcha css class to pa11y ignore, so the hidden textarea is not flagged.
- Remove the JavaScript hack that was a workaround
- Remove the specific google script, this is intended to be loaded by the general api.js script.