### PR TITLE
added redirects for old contract families

### DIFF
--- a/src/config/redirects.js
+++ b/src/config/redirects.js
@@ -6,6 +6,7 @@ import path from "path"
 
 const redirects = {
   "/ordering-guide/": "/oasis-plus/buyers-guide/printable/",
+  "/about/contract-families/":"/oasis-plus/about/contracts/"
   
 }
 

--- a/src/config/redirects.js
+++ b/src/config/redirects.js
@@ -6,7 +6,7 @@ import path from "path"
 
 const redirects = {
   "/ordering-guide/": "/oasis-plus/buyers-guide/printable/",
-  "/about/contract-families/":"/oasis-plus/about/contracts/"
+  "/about/contract-families/":"/oasis-plus/about/contracts/",
   
 }
 


### PR DESCRIPTION
add redirects for old contract families path, so user try to access bookmarked "(https://www.gsa.gov/oasis-plus/about/contract-families/)" goes to the new named Contracts (https://www.gsa.gov/oasis-plus/about/contracts/)