### PR TITLE
Add aria-labels to ImageListItems. 

### DIFF
--- a/src/components/ImageListItem.astro
+++ b/src/components/ImageListItem.astro
@@ -1,9 +1,11 @@
 ---
-const {image, image_width, url} = Astro.props;
+const {image, image_width, url, alt} = Astro.props;
 ---
 <li class="usa-icon-list__item padding-bottom-2">
     <div class="usa-icon-list__icon">
-      <a href={`${import.meta.env.BASE_URL}${url}`}><img src={image.src} style=`width:${image_width}` aria-hidden="true" role="img" alt=""></a>
+      <a href={`${import.meta.env.BASE_URL}${url}`} aria-label={alt}>
+        <img src={image.src} style=`width:${image_width}` aria-hidden="true" role="img" alt="">
+      </a>
     </div>
     <div class="usa-icon-list__content">
        <slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -192,7 +192,7 @@ const base_url = import.meta.env.BASE_URL;
                         ['Facilities', facilities_icon, 'about/domains-naicscodes-scope-labor-categories/#-facilities-fac'],
                         ['Technical & Engineering', tech_engineering_icon,'about/domains-naicscodes-scope-labor-categories/#-technical-and-engineering-te'],
                         ['Logistics', logistics_icon,'about/domains-naicscodes-scope-labor-categories/#-logistics-log']
-                      ].map(([text, img, url]) =>  <ImageListItem image={img} image_width="50px" url={url}>{text}</ImageListItem>) }
+                      ].map(([text, img, url]) =>  <ImageListItem image={img} image_width="50px" alt={text} url={url}>{text}</ImageListItem>) }
                     </ImageList>
                   </div>
 
@@ -203,7 +203,7 @@ const base_url = import.meta.env.BASE_URL;
                       ['Research & Development', r_d_icon,'about/domains-naicscodes-scope-labor-categories/#-research-and-development-rd'],
                       ['Environmental', environmental_icon,'about/domains-naicscodes-scope-labor-categories/#-environmental-env'],
                       ['Enterprise Solutions ', enterprise_icon,'about/domains-naicscodes-scope-labor-categories/#-enterprise-solutions']
-                    ].map(([text, img, url]) =>  <ImageListItem image={img} image_width="50px" url={url}>{text}</ImageListItem>) }
+                    ].map(([text, img, url]) =>  <ImageListItem image={img} image_width="50px" alt={text} url={url}>{text}</ImageListItem>) }
                     </ImageList>
                   </div>
                 </div>


### PR DESCRIPTION
This is an issue flagged by SiteImprove:

Since these links in ImageListItems only contain image content they need some text for screen readers. Adding an `aria-label` to the anchors should fix this and allow users with screen readers to understand what the links reference.