### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20
           cache: npm
       - name: Install dependencies
         run: npm ci
@@ -31,11 +31,11 @@ jobs:
     needs: setup
     steps:
       - name: Checkout code from ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20
           cache: npm
       - name: Install dependencies
         run: npm ci
@@ -47,11 +47,11 @@ jobs:
     needs: setup
     steps:
       - name: Checkout code from ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20
           cache: npm
       - name: Install dependencies
         run: npm ci
@@ -63,11 +63,11 @@ jobs:
     needs: setup
     steps:
       - name: Checkout code from ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20
           cache: npm
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Ensure we're on the latest version of actions, [see breaking changes](https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/).

Alyssa encountered failed checks [on April 1 in this PR](https://github.com/GSA/oasis-plus/pull/975) due to a brownout.